### PR TITLE
don't trust `totalItems` but just iterate over `orderedItems`

### DIFF
--- a/mastodon-data-viewer.py
+++ b/mastodon-data-viewer.py
@@ -418,16 +418,16 @@ def load_toots(actor):
 	toots = {}
 	with open(actor["outbox"], 'rb') as f:
 		j = bigjson.load(f)
-		totalItems = j["totalItems"]
-		allItems = j["orderedItems"]
 		print("Loading toots for the first time")
-		for i in tqdm(range(totalItems)):
-			item = allItems[i]
+		t = tqdm(total=0, unit="toots")
+		for item in j["orderedItems"]:
 			if (item["type"] != "Create"):
 				continue
 			obj = item["object"].to_python()
 			toots[obj["id"]] = obj
+			t.update()
 	pickle.dump(toots, open("toots.pk", "wb"))
+	t.close()
 	return toots
 
 def bin_monthly(toots):


### PR DESCRIPTION
In one of my archives, `totalItems` in `outbox.json` was over 1,000 items short. I've fixed this by iterating directly on `orderedItems`.

Counting `orderedItems` first with `len` made the script pause a good amount of time, so I switched tqdm to dynamic mode in the interest of speed.

(It's interesting to note that [the spec for `totalItems`](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-totalitems) says "This number might not reflect the actual number of items serialized…".)