### PR TITLE
Command line options

### DIFF
--- a/mastodon-data-viewer.py
+++ b/mastodon-data-viewer.py
@@ -468,7 +468,7 @@ def main():
 	parser.add_argument("--port", "-p", default=DEFAULT_PORT, type=int, help="Port number for the web server")
 	parser.add_argument("--archive", "-a", default=DEFAULT_ARCHIVE_PATH, help="Path to Mastodon's outbox.json and actor.json")
 	parser.add_argument("--cache", "-c", default="./", help="Path where the cache files will be stored")
-	parser.add_argument("--rebuild", "-r", default=False, help="Rebuilds the toots.pk cache file")
+	parser.add_argument("--force-update", "-r", default=False, help="Forces rebuild of the toots.pk cache file")
 	parser.add_argument("--dont-update", "-u", default=False, help="Does not update the toots cache with data files", action='store_true')
 	args = parser.parse_args()
 
@@ -491,7 +491,7 @@ def main():
 	with open(outbox_path, 'rb') as f:
 		new_hash = hashlib.sha256(f.read()).hexdigest()
 
-	if path.isfile(toots_path) and path.isfile(hash_path) and not args.rebuild:
+	if path.isfile(toots_path) and path.isfile(hash_path) and not args.force_update:
 		with open(toots_path, "rb") as f:
 			toots = pickle.load(f)
 		with open(hash_path, "r") as f:


### PR DESCRIPTION
## Added
- Command line options with argparse
  - Port: To change port number the webserver will be listening in
  - Hostname: Hostname the webserver will listen for
  - Archive: Path to the archive data (outbox.json and actor.json)
  - Rebuild: Forces rebuild of toots.pk
  - Dont-Update: Ignores changes on archive files and does not update toots.pk
  - Force-Update: Rebuilds the toots.pk regardless of the state of the archive
  - Use Outbox: Simply reads outbox.json, and does not fetch the path from actor.json
  - Script can still be run normally without any of the command line options
- Now checking for changes on archive files with every launch
  - Only read toots if SHA256 on outbox.json does not match hash.sha256, or if it and/or the toots.pk file is not present
    - Command line flags can also force/stop the script from re-processing the archive
  - Prints out how many toots were added/removed

## Modified
- `load_toots` now expects path instead of dictionary
- Added default variables at the top of the script
```python
DEFAULT_HOST 			= "localhost"
DEFAULT_PORT 			= 8000
DEFAULT_ARCHIVE_PATH	= "./"
```